### PR TITLE
omit hard-coded user location and destination

### DIFF
--- a/server/routes/rideRequests.js
+++ b/server/routes/rideRequests.js
@@ -6,17 +6,17 @@ var region = require('../utility/inRegion');
 
 router.post('/', function(req, res) {
 
-// hard-coded req.body for Postman testing
-  // Hack Reactor
-  req.body.currentLocation = {
-    lat: 37.783759,
-    lon: -122.402712
-  }
-  // Ferry Building
-  req.body.destination = {
-    lat: 37.795581, 
-    lon: -122.393411
-  }
+// // hard-coded req.body for Postman testing
+//   // Hack Reactor
+//   req.body.currentLocation = {
+//     lat: 37.783759,
+//     lon: -122.402712
+//   }
+//   // Ferry Building
+//   req.body.destination = {
+//     lat: 37.795581, 
+//     lon: -122.393411
+//   }
 
  var destLat = req.body.destination.lat;
  var destLon = req.body.destination.lon;


### PR DESCRIPTION
Server expects "req.body.destination.lat" and "req.body.destination.lon" for post request
